### PR TITLE
Add button to sort repositories by new issues

### DIFF
--- a/components/Picker/SortPicker.tsx
+++ b/components/Picker/SortPicker.tsx
@@ -18,6 +18,7 @@ export const SortPicker = ({ activeSort, sortOptions, onSortOrderSelect }: SortP
       </div>
       <div>
         {sortOptions.map((sortOption) => {
+          console.log(sortOption);
           return (
             <button
               key={sortOption}

--- a/components/Picker/SortPicker.tsx
+++ b/components/Picker/SortPicker.tsx
@@ -18,7 +18,6 @@ export const SortPicker = ({ activeSort, sortOptions, onSortOrderSelect }: SortP
       </div>
       <div>
         {sortOptions.map((sortOption) => {
-          console.log(sortOption);
           return (
             <button
               key={sortOption}

--- a/constants.ts
+++ b/constants.ts
@@ -1,6 +1,7 @@
 import { RepositorySortOrder } from "./types";
 
 export const REPOSITORY_SORT_OPTIONS = [
+  RepositorySortOrder.NEW_ISSUES,
   RepositorySortOrder.LEAST_STARS,
   RepositorySortOrder.MOST_STARS,
   RepositorySortOrder.NONE

--- a/context/AppDataContext.tsx
+++ b/context/AppDataContext.tsx
@@ -63,6 +63,7 @@ const AppDataProvider = ({ children }: { children: React.ReactNode }) => {
   const updateRepositoriesOnSortChange = (sortOrder: RepositorySortOrder) => {
     let updatedRepositories: Repository[] = [];
 
+    //Find and return the newest issue in a given repository
     if (sortOrder === RepositorySortOrder.NEW_ISSUES) {
       function getNewestIssue(repository: Repository): Issue {
         const sortedIssues = [...repository.issues].sort((a, b) => {
@@ -70,7 +71,6 @@ const AppDataProvider = ({ children }: { children: React.ReactNode }) => {
           const dateB = new Date(b.created_at).getTime();
           return dateB - dateA; 
         });
-        // Return the repo's newest issue
         return sortedIssues[0]; 
       }
       //Compare current repo's newest issue to next repo's newest issue, sort by newest issue first

--- a/context/AppDataContext.tsx
+++ b/context/AppDataContext.tsx
@@ -6,6 +6,7 @@ import {
   CountableLanguage,
   CountableTag,
   Repository,
+  Issue,
   RepositorySortOrder
 } from "../types";
 
@@ -61,6 +62,26 @@ const AppDataProvider = ({ children }: { children: React.ReactNode }) => {
 
   const updateRepositoriesOnSortChange = (sortOrder: RepositorySortOrder) => {
     let updatedRepositories: Repository[] = [];
+
+    if (sortOrder === RepositorySortOrder.NEW_ISSUES) {
+      function getNewestIssue(repository: Repository): Issue {
+        const sortedIssues = [...repository.issues].sort((a, b) => {
+          const dateA = new Date(a.created_at).getTime();
+          const dateB = new Date(b.created_at).getTime();
+          return dateB - dateA; // Sort in descending order
+        });
+
+        return sortedIssues[0]; // The first element is the newest issue
+      }
+
+      updatedRepositories = [...allRepositories].sort((currentRepository, nextRepository) => {
+        const currentNewestIssue =  getNewestIssue(currentRepository);
+        const nextNewestIssue = getNewestIssue(nextRepository);
+
+        return nextNewestIssue < currentNewestIssue ? allRepositories.indexOf(nextRepository) - allRepositories.indexOf(currentRepository) 
+        : allRepositories.indexOf(currentRepository) - allRepositories.indexOf(nextRepository);
+      });
+    }
 
     if (sortOrder === RepositorySortOrder.MOST_STARS) {
       updatedRepositories = [...allRepositories].sort((currentRepository, nextRepository) => {

--- a/context/AppDataContext.tsx
+++ b/context/AppDataContext.tsx
@@ -68,18 +68,18 @@ const AppDataProvider = ({ children }: { children: React.ReactNode }) => {
         const sortedIssues = [...repository.issues].sort((a, b) => {
           const dateA = new Date(a.created_at).getTime();
           const dateB = new Date(b.created_at).getTime();
-          return dateB - dateA; // Sort in descending order
+          return dateB - dateA; 
         });
-
-        return sortedIssues[0]; // The first element is the newest issue
+        // Return the repo's newest issue
+        return sortedIssues[0]; 
       }
-
+      //Compare current repo's newest issue to next repo's newest issue, sort by newest issue first
       updatedRepositories = [...allRepositories].sort((currentRepository, nextRepository) => {
-        const currentNewestIssue =  getNewestIssue(currentRepository);
+        const currentNewestIssue = getNewestIssue(currentRepository);
         const nextNewestIssue = getNewestIssue(nextRepository);
+        const timestampDiff = new Date(nextNewestIssue.created_at).getTime() - new Date(currentNewestIssue.created_at).getTime();
 
-        return nextNewestIssue < currentNewestIssue ? allRepositories.indexOf(nextRepository) - allRepositories.indexOf(currentRepository) 
-        : allRepositories.indexOf(currentRepository) - allRepositories.indexOf(nextRepository);
+        return timestampDiff;
       });
     }
 

--- a/types.ts
+++ b/types.ts
@@ -59,7 +59,7 @@ export interface Label {
 }
 
 export enum RepositorySortOrder {
-  NEW_ISSUES = "Newest Issues",
+  NEW_ISSUES = "New Issues",
   LEAST_STARS = "By Least Stars",
   MOST_STARS = "By Most Stars",
   NONE = "None"

--- a/types.ts
+++ b/types.ts
@@ -59,6 +59,7 @@ export interface Label {
 }
 
 export enum RepositorySortOrder {
+  NEW_ISSUES = "Newest Issues",
   LEAST_STARS = "By Least Stars",
   MOST_STARS = "By Most Stars",
   NONE = "None"


### PR DESCRIPTION
Added a "New Issues" button that finds the newest issue in each repo and compares them to each other, then renders newest issues first. 