### PR TITLE
docs: add conventional commit messages guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -157,7 +157,27 @@ TBD
 
 ### Commit Messages
 
-TBD
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification. Each commit message consists of a **type** and a **description**:
+
+```
+type: description
+
+Longer explanation if needed. Wrap at 72 characters.
+```
+
+**Types:**
+- `feat` — new feature
+- `fix` — bug fix
+- `refactor` — code restructuring
+- `docs` — documentation changes
+- `test` — adding or updating tests
+- `ci` — CI/CD changes
+- `chore` — maintenance tasks
+
+**Examples:**
+- `feat: add user authentication`
+- `fix: correct redirect URL after login`
+- `docs: update README with installation steps`
 
 ## Join The Project Team
 


### PR DESCRIPTION
## Summary
- Added Conventional Commits guide to the Commit Messages section
- Includes format specification, type definitions, and examples

## Changes
- Replaced "TBD" placeholder with comprehensive commit message guidelines

## Test Plan
- [x] Content follows Conventional Commits specification
- [x] Examples are clear and actionable

Closes #392